### PR TITLE
updated defaults, require f' when calling f'', updated tests accordingly

### DIFF
--- a/src/check_derivative.jl
+++ b/src/check_derivative.jl
@@ -8,12 +8,12 @@ function check_gradient{T <: Number}(f::Function, g::Function, x::Vector{T})
 	return maximum(abs(g(x) - auto_g(x)))
 end
 
-function check_second_derivative(f::Function, h::Function, x::Number)
-	auto_h = second_derivative(f)
+function check_second_derivative(f::Function, g::Function, h::Function, x::Number)
+	auto_h = second_derivative(f, g)
 	return maximum(abs(h(x) - auto_h(x)))
 end
 
-function check_hessian{T <: Number}(f::Function, h::Function, x::Vector{T})
-	auto_h = hessian(f)
+function check_hessian{T <: Number}(f::Function, g::Function, h::Function, x::Vector{T})
+	auto_h = hessian(f, g)
 	return maximum(abs(h(x) - auto_h(x)))
 end

--- a/src/derivative.jl
+++ b/src/derivative.jl
@@ -8,11 +8,13 @@ function derivative(f::Function, ftype::Symbol, dtype::Symbol)
   end
   return g
 end
+
 derivative{T <: Number}(f::Function, x::Union(T, Vector{T}), dtype::Symbol = :central) = finite_difference(f, float(x), dtype)
 derivative(f::Function, dtype::Symbol = :central) = derivative(f, :scalar, dtype)
 
 gradient{T <: Number}(f::Function, x::Union(T, Vector{T}), dtype::Symbol = :central) = finite_difference(f, float(x), dtype)
 gradient(f::Function, dtype::Symbol = :central) = derivative(f, :vector, dtype)
+
 
 ctranspose(f::Function) = derivative(f)
 
@@ -71,9 +73,5 @@ end
 function hessian{T <: Number}(f::Function, x::Vector{T})
   finite_difference_hessian(f, gradient(f), x, :central)
 end
-second_derivative(f::Function, g::Function, dtype::Symbol) = second_derivative(f, g, :scalar, dtype)
-second_derivative(f::Function, g::Function) = second_derivative(f, g, :scalar, :central)
-second_derivative(f::Function) = second_derivative(f, derivative(f), :scalar, :central)
-hessian(f::Function, g::Function, dtype::Symbol) = second_derivative(f, g, :vector, dtype)
-hessian(f::Function, g::Function) = second_derivative(f, g, :vector, :central)
-hessian(f::Function) = second_derivative(f, gradient(f), :vector, :central)
+second_derivative(f::Function, g::Function, dtype::Symbol=:central) = second_derivative(f, g, :scalar, dtype)
+hessian(f::Function, g::Function, dtype::Symbol=:central) = second_derivative(f, g, :vector, dtype)

--- a/test/check_derivative.jl
+++ b/test/check_derivative.jl
@@ -10,14 +10,14 @@
 @test check_gradient(x -> sin(x[1]) + cos(x[2]), x -> [cos(x[1]), -sin(x[2])], [100.0, 100.0]) < 10e-4
 @test check_gradient(x -> sin(x[1]) + cos(x[2]), x -> [cos(x[1]), -sin(x[2])], [1000.0, 1000.0]) < 10e-4
 
-@test check_second_derivative(x -> sin(x), x -> -sin(x), 0.0) < 10e-4
-@test check_second_derivative(x -> sin(x), x -> -sin(x), 1.0) < 10e-4
-@test check_second_derivative(x -> sin(x), x -> -sin(x), 10.0) < 10e-4
-@test check_second_derivative(x -> sin(x), x -> -sin(x), 100.0) < 10e-4
-@test check_second_derivative(x -> sin(x), x -> -sin(x), 1000.0) < 10e-4
+@test check_second_derivative(x -> sin(x), x -> cos(x), x -> -sin(x), 0.0) < 10e-4
+@test check_second_derivative(x -> sin(x), x -> cos(x), x -> -sin(x), 1.0) < 10e-4
+@test check_second_derivative(x -> sin(x), x -> cos(x), x -> -sin(x), 10.0) < 10e-4
+@test check_second_derivative(x -> sin(x), x -> cos(x), x -> -sin(x), 100.0) < 10e-4
+@test check_second_derivative(x -> sin(x), x -> cos(x), x -> -sin(x), 1000.0) < 10e-4
 
-@test check_hessian(x -> sin(x[1]) + cos(x[2]), x -> [-sin(x[1]) 0.0; 0.0 -cos(x[2])], [0.0, 0.0]) < 10e-4
-@test check_hessian(x -> sin(x[1]) + cos(x[2]), x -> [-sin(x[1]) 0.0; 0.0 -cos(x[2])], [1.0, 1.0]) < 10e-4
-@test check_hessian(x -> sin(x[1]) + cos(x[2]), x -> [-sin(x[1]) 0.0; 0.0 -cos(x[2])], [10.0, 10.0]) < 10e-4
-@test check_hessian(x -> sin(x[1]) + cos(x[2]), x -> [-sin(x[1]) 0.0; 0.0 -cos(x[2])], [100.0, 100.0]) < 10e-4
-@test check_hessian(x -> sin(x[1]) + cos(x[2]), x -> [-sin(x[1]) 0.0; 0.0 -cos(x[2])], [1000.0, 1000.0]) < 10e-4
+@test check_hessian(x -> sin(x[1]) + cos(x[2]), x -> [cos(x[1]), -sin(x[2])], x -> [-sin(x[1]) 0.0; 0.0 -cos(x[2])], [0.0, 0.0]) < 10e-4
+@test check_hessian(x -> sin(x[1]) + cos(x[2]), x -> [cos(x[1]), -sin(x[2])], x -> [-sin(x[1]) 0.0; 0.0 -cos(x[2])], [1.0, 1.0]) < 10e-4
+@test check_hessian(x -> sin(x[1]) + cos(x[2]), x -> [cos(x[1]), -sin(x[2])], x -> [-sin(x[1]) 0.0; 0.0 -cos(x[2])], [10.0, 10.0]) < 10e-4
+@test check_hessian(x -> sin(x[1]) + cos(x[2]), x -> [cos(x[1]), -sin(x[2])], x -> [-sin(x[1]) 0.0; 0.0 -cos(x[2])], [100.0, 100.0]) < 10e-4
+@test check_hessian(x -> sin(x[1]) + cos(x[2]), x -> [cos(x[1]), -sin(x[2])], x -> [-sin(x[1]) 0.0; 0.0 -cos(x[2])], [1000.0, 1000.0]) < 10e-4

--- a/test/derivative.jl
+++ b/test/derivative.jl
@@ -35,15 +35,16 @@ f4(x::Vector) = (100.0 - x[1])^2 + (50.0 - x[2])^2
 # second_derivative()
 #
 
-@test norm(second_derivative(x -> x^2)(0.0) - 2.0) < 10e-4
-@test norm(second_derivative(x -> x^2)(1.0) - 2.0) < 10e-4
-@test norm(second_derivative(x -> x^2)(10.0) - 2.0) < 10e-4
-@test norm(second_derivative(x -> x^2)(100.0) - 2.0) < 10e-4
+@test norm(second_derivative(x -> x^2, x -> 2*x)(0.0) - 2.0) < 10e-4
+@test norm(second_derivative(x -> x^2, x -> 2*x)(1.0) - 2.0) < 10e-4
+@test norm(second_derivative(x -> x^2, x -> 2*x)(10.0) - 2.0) < 10e-4
+@test norm(second_derivative(x -> x^2, x -> 2*x)(100.0) - 2.0) < 10e-4
 
 #
 # hessian()
 #
 
 f5(x) = sin(x[1]) + cos(x[2])
+g5(x) = [cos(x[1]), -sin(x[2])]
 @test norm(gradient(f5)([0.0, 0.0]) - [cos(0.0), -sin(0.0)]) < 10e-4
-@test norm(hessian(f5)([0.0, 0.0]) - [-sin(0.0) 0.0; 0.0 -cos(0.0)]) < 10e-4
+@test norm(hessian(f5,g5)([0.0, 0.0]) - [-sin(0.0) 0.0; 0.0 -cos(0.0)]) < 10e-4


### PR DESCRIPTION
This is just [this PR](https://github.com/johnmyleswhite/Calculus.jl/pull/19) rebased against master. I made the mistake of making that PR from my own master branch, and I wanted to hack a little so I did a little spring cleaning.  The original PR message was:

> > > Cleaned up the functions in derivative to use defaults, and removed the calls to second_derivative and hessian (as discussed in Issue 18). I also updated the tests to reflect the changes.

I'm not actually sure if this is relevant anymore, so feel free to close if it's not!
