### PR TITLE
Remove lower bound on size of epsilon

### DIFF
--- a/src/derivative.jl
+++ b/src/derivative.jl
@@ -35,7 +35,7 @@ else
     Base.ctranspose(f::Function) = derivative(f)
 end
 
-function jacobian(f, x::Vector{T}, dtype::Symbol) where T <: Number
+function jacobian(f, x::AbstractVector{T}, dtype::Symbol) where T <: Number
     finite_difference_jacobian(f, x, dtype)
 end
 function jacobian(f, dtype::Symbol)

--- a/src/finite_difference.jl
+++ b/src/finite_difference.jl
@@ -17,21 +17,21 @@
 macro forwardrule(x, e)
     x, e = esc(x), esc(e)
     quote
-        $e = sqrt(eps(eltype($x))) * max(one(eltype($x)), abs($x))
+        $e = sqrt(eps($x^2))
     end
 end
 
 macro centralrule(x, e)
     x, e = esc(x), esc(e)
     quote
-        $e = cbrt(eps(eltype($x))) * max(one(eltype($x)), abs($x))
+        $e = cbrt(eps($x^3))
     end
 end
 
 macro hessianrule(x, e)
     x, e = esc(x), esc(e)
     quote
-        $e = eps(eltype($x))^(1/4) * max(one(eltype($x)), abs($x))
+        $e = eps($x^4)^(1/4)
     end
 end
 

--- a/test/check_derivative.jl
+++ b/test/check_derivative.jl
@@ -1,23 +1,31 @@
-@test check_derivative(x -> sin(x), x -> cos(x), 0.0) < 10e-4
-@test check_derivative(x -> sin(x), x -> cos(x), 1.0) < 10e-4
-@test check_derivative(x -> sin(x), x -> cos(x), 10.0) < 10e-4
-@test check_derivative(x -> sin(x), x -> cos(x), 100.0) < 10e-4
-@test check_derivative(x -> sin(x), x -> cos(x), 1000.0) < 10e-4
+@testset "check_derivative: f(x) = sin(x)" begin
+    @test check_derivative(x -> sin(x), x -> cos(x), 0.0) < 10e-4
+    @test check_derivative(x -> sin(x), x -> cos(x), 1.0) < 10e-4
+    @test check_derivative(x -> sin(x), x -> cos(x), 10.0) < 10e-4
+    @test check_derivative(x -> sin(x), x -> cos(x), 100.0) < 10e-4
+    @test check_derivative(x -> sin(x), x -> cos(x), 1000.0) < 10e-4
+end
 
-@test check_gradient(x -> sin(x[1]) + cos(x[2]), x -> [cos(x[1]), -sin(x[2])], [0.0, 0.0]) < 10e-4
-@test check_gradient(x -> sin(x[1]) + cos(x[2]), x -> [cos(x[1]), -sin(x[2])], [1.0, 1.0]) < 10e-4
-@test check_gradient(x -> sin(x[1]) + cos(x[2]), x -> [cos(x[1]), -sin(x[2])], [10.0, 10.0]) < 10e-4
-@test check_gradient(x -> sin(x[1]) + cos(x[2]), x -> [cos(x[1]), -sin(x[2])], [100.0, 100.0]) < 10e-4
-@test check_gradient(x -> sin(x[1]) + cos(x[2]), x -> [cos(x[1]), -sin(x[2])], [1000.0, 1000.0]) < 10e-4
+@testset "check_gradient: f(x) = sin(x[1]) + cos(x[2])" begin
+    @test check_gradient(x -> sin(x[1]) + cos(x[2]), x -> [cos(x[1]), -sin(x[2])], [0.1, 0.1]) < 10e-4
+    @test check_gradient(x -> sin(x[1]) + cos(x[2]), x -> [cos(x[1]), -sin(x[2])], [1.0, 1.0]) < 10e-4
+    @test check_gradient(x -> sin(x[1]) + cos(x[2]), x -> [cos(x[1]), -sin(x[2])], [10.0, 10.0]) < 10e-4
+    @test check_gradient(x -> sin(x[1]) + cos(x[2]), x -> [cos(x[1]), -sin(x[2])], [100.0, 100.0]) < 10e-4
+    @test check_gradient(x -> sin(x[1]) + cos(x[2]), x -> [cos(x[1]), -sin(x[2])], [1000.0, 1000.0]) < 10e-4
+end
 
-@test check_second_derivative(x -> sin(x), x -> -sin(x), 0.0) < 10e-4
-@test check_second_derivative(x -> sin(x), x -> -sin(x), 1.0) < 10e-4
-@test check_second_derivative(x -> sin(x), x -> -sin(x), 10.0) < 10e-4
-@test check_second_derivative(x -> sin(x), x -> -sin(x), 100.0) < 10e-4
-@test check_second_derivative(x -> sin(x), x -> -sin(x), 1000.0) < 10e-4
+@testset "check_second_derivative: f(x) = sin(x)" begin
+    @test check_second_derivative(x -> sin(x), x -> -sin(x), 0.0) < 10e-4
+    @test check_second_derivative(x -> sin(x), x -> -sin(x), 1.0) < 10e-4
+    @test check_second_derivative(x -> sin(x), x -> -sin(x), 10.0) < 10e-4
+    @test check_second_derivative(x -> sin(x), x -> -sin(x), 100.0) < 10e-4
+    @test check_second_derivative(x -> sin(x), x -> -sin(x), 1000.0) < 10e-4
+end
 
-@test check_hessian(x -> sin(x[1]) + cos(x[2]), x -> [-sin(x[1]) 0.0; 0.0 -cos(x[2])], [0.0, 0.0]) < 10e-4
-@test check_hessian(x -> sin(x[1]) + cos(x[2]), x -> [-sin(x[1]) 0.0; 0.0 -cos(x[2])], [1.0, 1.0]) < 10e-4
-@test check_hessian(x -> sin(x[1]) + cos(x[2]), x -> [-sin(x[1]) 0.0; 0.0 -cos(x[2])], [10.0, 10.0]) < 10e-4
-@test check_hessian(x -> sin(x[1]) + cos(x[2]), x -> [-sin(x[1]) 0.0; 0.0 -cos(x[2])], [100.0, 100.0]) < 10e-4
-@test check_hessian(x -> sin(x[1]) + cos(x[2]), x -> [-sin(x[1]) 0.0; 0.0 -cos(x[2])], [1000.0, 1000.0]) < 10e-4
+@testset "check_hessian: f(x) = sin(x[1]) + cos(x[2])" begin
+    @test check_hessian(x -> sin(x[1]) + cos(x[2]), x -> [-sin(x[1]) 0.0; 0.0 -cos(x[2])], [0.1, 0.1]) < 10e-4
+    @test check_hessian(x -> sin(x[1]) + cos(x[2]), x -> [-sin(x[1]) 0.0; 0.0 -cos(x[2])], [1.0, 1.0]) < 10e-4
+    @test check_hessian(x -> sin(x[1]) + cos(x[2]), x -> [-sin(x[1]) 0.0; 0.0 -cos(x[2])], [10.0, 10.0]) < 10e-4
+    @test check_hessian(x -> sin(x[1]) + cos(x[2]), x -> [-sin(x[1]) 0.0; 0.0 -cos(x[2])], [100.0, 100.0]) < 10e-4
+    @test check_hessian(x -> sin(x[1]) + cos(x[2]), x -> [-sin(x[1]) 0.0; 0.0 -cos(x[2])], [1000.0, 1000.0]) < 10e-4
+end

--- a/test/derivative.jl
+++ b/test/derivative.jl
@@ -2,55 +2,75 @@
 # derivative()
 #
 
-f1(x::Real) = sin(x)
-@test norm(derivative(f1, :scalar, :forward)(0.0) - cos(0.0)) < 10e-4
-@test norm(derivative(f1, :scalar, :central)(0.0) - cos(0.0)) < 10e-4
-@test norm(derivative(f1, :forward)(0.0) - cos(0.0)) < 10e-4
-@test norm(derivative(f1, :central)(0.0) - cos(0.0)) < 10e-4
-@test norm(derivative(f1)(0.0) - cos(0.0)) < 10e-4
+@testset "derivative()" begin
+    @testset "f(x::Real) = sin(x)" begin
+        f1(x::Real) = sin(x)
+        @test norm(derivative(f1, :scalar, :forward)(0.0) - cos(0.0)) < 10e-4
+        @test norm(derivative(f1, :scalar, :central)(0.0) - cos(0.0)) < 10e-4
+        @test norm(derivative(f1, :forward)(0.0) - cos(0.0)) < 10e-4
+        @test norm(derivative(f1, :central)(0.0) - cos(0.0)) < 10e-4
+        @test norm(derivative(f1)(0.0) - cos(0.0)) < 10e-4
+    end
 
-f2(x::Vector) = sin(x[1])
-@test norm(derivative(f2, :vector, :forward)([0.0]) .- cos(0.0)) < 10e-4
-@test norm(derivative(f2, :vector, :central)([0.0]) .- cos(0.0)) < 10e-4
+    @testset "f(x::Vector) = sin(x[1])" begin
+        f2(x::Vector) = sin(x[1])
+        @test norm(derivative(f2, :vector, :forward)([0.0]) .- cos(0.0)) < 10e-4
+        @test norm(derivative(f2, :vector, :central)([0.0]) .- cos(0.0)) < 10e-4
+    end
+end
 
 #
 # adjoint overloading
 #
 
-f3(x::Real) = sin(x)
-for x in Compat.range(0.0, stop=0.1, length=11) # seq()
-    @test norm(f3'(x) - cos(x)) < 10e-4
+@testset "adjoint overloading" begin
+    @testset "f(x::Vector) = sin(x[1])" begin
+        f3(x::Real) = sin(x)
+        for x in Compat.range(0.0, stop=0.1, length=11) # seq()
+            @test norm(f3'(x) - cos(x)) < 10e-4
+        end
+    end
 end
 
 #
 # gradient()
 #
 
-f4(x::Vector) = (100.0 - x[1])^2 + (50.0 - x[2])^2
-@test norm(Calculus.gradient(f4, :forward)([100.0, 50.0]) - [0.0, 0.0]) < 10e-4
-@test norm(Calculus.gradient(f4, :central)([100.0, 50.0]) - [0.0, 0.0]) < 10e-4
-@test norm(Calculus.gradient(f4)([100.0, 50.0]) - [0.0, 0.0]) < 10e-4
+@testset "gradient()" begin
+    f4(x::Vector) = (100.0 - x[1])^2 + (50.0 - x[2])^2
+    @test norm(Calculus.gradient(f4, :forward)([100.0, 50.0]) - [0.0, 0.0]) < 10e-4
+    @test norm(Calculus.gradient(f4, :central)([100.0, 50.0]) - [0.0, 0.0]) < 10e-4
+    @test norm(Calculus.gradient(f4)([100.0, 50.0]) - [0.0, 0.0]) < 10e-4
+end
 
 #
 # jacobian()
 #
 
-@test norm(Calculus.jacobian(identity, rand(3), :forward) - Matrix(1.0I, 3, 3)) < 10e-4
-@test norm(Calculus.jacobian(identity, rand(3), :central) - Matrix(1.0I, 3, 3)) < 10e-4
+@testset "jacobian()" begin
+    @test norm(Calculus.jacobian(identity, rand(3), :forward) - Matrix(1.0I, 3, 3)) < 10e-4
+    @test norm(Calculus.jacobian(identity, rand(3), :central) - Matrix(1.0I, 3, 3)) < 10e-4
+end
 
 #
 # second_derivative()
 #
 
-@test norm(second_derivative(x -> x^2)(0.0) - 2.0) < 10e-4
-@test norm(second_derivative(x -> x^2)(1.0) - 2.0) < 10e-4
-@test norm(second_derivative(x -> x^2)(10.0) - 2.0) < 10e-4
-@test norm(second_derivative(x -> x^2)(100.0) - 2.0) < 10e-4
+@testset "second_derivative()" begin
+    @test norm(second_derivative(x -> x^2)(0.0) - 2.0) < 10e-4
+    @test norm(second_derivative(x -> x^2)(1.0) - 2.0) < 10e-4
+    @test norm(second_derivative(x -> x^2)(10.0) - 2.0) < 10e-4
+    @test norm(second_derivative(x -> x^2)(100.0) - 2.0) < 10e-4
+end
 
 #
 # hessian()
 #
 
-f5(x) = sin(x[1]) + cos(x[2])
-@test norm(Calculus.gradient(f5)([0.0, 0.0]) - [cos(0.0), -sin(0.0)]) < 10e-4
-@test norm(hessian(f5)([0.0, 0.0]) - [-sin(0.0) 0.0; 0.0 -cos(0.0)]) < 10e-4
+@testset "hessian()" begin
+    f5(x) = sin(x[1]) + cos(x[2])
+    x₁, x₂ = 1.0, 1.0
+    x = [x₁, x₂]
+    @test norm(Calculus.gradient(f5)(x) - [cos(x₁), -sin(x₂)]) < 10e-4
+    @test norm(hessian(f5)(x) - [-sin(x₁) 0.0; 0.0 -cos(x₂)]) < 10e-4
+end

--- a/test/finite_difference.jl
+++ b/test/finite_difference.jl
@@ -2,62 +2,95 @@
 # Derivatives of f: R -> R
 #
 
-@test norm(Calculus.finite_difference(x -> x^2, 1.0, :forward) - 2.0) < 10e-4
-@test norm(Calculus.finite_difference(x -> x^2, 1.0, :central) - 2.0) < 10e-4
-@test norm(Calculus.finite_difference(x -> x^2, 1.0) - 2.0) < 10e-4
+@testset "Derivatives of f: R -> R" begin
+    @testset "f(x) = x²" begin
+        @testset "x = $x" for x in 10.0.^collect(-10:10)
+            @test Calculus.finite_difference(x -> x^2, x, :forward) ≈ 2x rtol = 1e-4
+            @test Calculus.finite_difference(x -> x^2, x, :central) ≈ 2x rtol = 1e-4
+            @test Calculus.finite_difference(x -> x^2, x)           ≈ 2x rtol = 1e-4
+        end
+    end
 
-@test norm(Calculus.finite_difference(x -> sin(x), 1.0, :forward) - cos(1.0)) < 10e-4
-@test norm(Calculus.finite_difference(x -> sin(x), 1.0, :central) - cos(1.0)) < 10e-4
-@test norm(Calculus.finite_difference(x -> sin(x), 1.0) - cos(1.0)) < 10e-4
+    @testset "f(x) = sin(x)" begin
+        @testset "x = $x" for x in 10.0.^collect(-10:1)
+            @test Calculus.finite_difference(x -> sin(x), x, :forward) ≈ cos(x) rtol = 1e-4
+            @test Calculus.finite_difference(x -> sin(x), x, :central) ≈ cos(x) rtol = 1e-4
+            @test Calculus.finite_difference(x -> sin(x), x)           ≈ cos(x) rtol = 1e-4
+        end
+    end
 
-@test norm(Calculus.finite_difference(x -> exp(-x), 1.0, :forward) - (-exp(-1.0))) < 10e-4
-@test norm(Calculus.finite_difference(x -> exp(-x), 1.0, :central) - (-exp(-1.0))) < 10e-4
-@test norm(Calculus.finite_difference(x -> exp(-x), 1.0) - (-exp(-1.0))) < 10e-4
+    @testset "f(x) = exp(-x)" begin
+        @testset "x = $x" for x in 10.0.^collect(-1:10)
+            @test Calculus.finite_difference(x -> exp(-x), x, :forward) ≈ -exp(-x) rtol = 1e-4
+            @test Calculus.finite_difference(x -> exp(-x), x, :central) ≈ -exp(-x) rtol = 1e-4
+            @test Calculus.finite_difference(x -> exp(-x), x)           ≈ -exp(-x) rtol = 1e-4
+        end
+    end
+
+    @testset "f(x) = log(x)" begin
+        @testset "x = $x" for x in 10.0.^collect(-10:10)
+            @test Calculus.finite_difference(x -> log(x), x, :forward) ≈ 1/x rtol = 1e-4
+            @test Calculus.finite_difference(x -> log(x), x, :central) ≈ 1/x rtol = 1e-4
+            @test Calculus.finite_difference(x -> log(x), x, :complex) ≈ 1/x rtol = 1e-4
+        end
+    end
+end
+
 
 #
 # Gradients of f: R^n -> R
 #
 
-@test norm(Calculus.finite_difference(x -> x[1]^2, [1.0], :forward) - [2.0]) < 10e-4
-@test norm(Calculus.finite_difference(x -> x[1]^2, [1.0], :central) - [2.0]) < 10e-4
-@test norm(Calculus.finite_difference(x -> x[1]^2, [1.0]) - [2.0]) < 10e-4
+@testset "Gradients of f: R^n -> R" begin
+    @test norm(Calculus.finite_difference(x -> x[1]^2, [1.0], :forward) - [2.0]) < 10e-4
+    @test norm(Calculus.finite_difference(x -> x[1]^2, [1.0], :central) - [2.0]) < 10e-4
+    @test norm(Calculus.finite_difference(x -> x[1]^2, [1.0]) - [2.0]) < 10e-4
 
-@test norm(Calculus.finite_difference(x -> sin(x[1]), [1.0], :forward) - [cos(1.0)]) < 10e-4
-@test norm(Calculus.finite_difference(x -> sin(x[1]), [1.0], :central) - [cos(1.0)]) < 10e-4
-@test norm(Calculus.finite_difference(x -> sin(x[1]), [1.0]) - [cos(1.0)]) < 10e-4
+    @test norm(Calculus.finite_difference(x -> sin(x[1]), [1.0], :forward) - [cos(1.0)]) < 10e-4
+    @test norm(Calculus.finite_difference(x -> sin(x[1]), [1.0], :central) - [cos(1.0)]) < 10e-4
+    @test norm(Calculus.finite_difference(x -> sin(x[1]), [1.0]) - [cos(1.0)]) < 10e-4
 
-@test norm(Calculus.finite_difference(x -> exp(-x[1]), [1.0], :forward) - [-exp(-1.0)]) < 10e-4
-@test norm(Calculus.finite_difference(x -> exp(-x[1]), [1.0], :central) - [-exp(-1.0)]) < 10e-4
-@test norm(Calculus.finite_difference(x -> exp(-x[1]), [1.0]) - [-exp(-1.0)]) < 10e-4
+    @test norm(Calculus.finite_difference(x -> exp(-x[1]), [1.0], :forward) - [-exp(-1.0)]) < 10e-4
+    @test norm(Calculus.finite_difference(x -> exp(-x[1]), [1.0], :central) - [-exp(-1.0)]) < 10e-4
+    @test norm(Calculus.finite_difference(x -> exp(-x[1]), [1.0]) - [-exp(-1.0)]) < 10e-4
+end
 
 #
 # Second derivatives of f: R -> R
 #
 
-@test norm(Calculus.finite_difference_hessian(x -> x^2, x -> 2 * x, 1.0) - 2.0) < 10e-4
-@test norm(Calculus.finite_difference_hessian(x -> x^2, x -> 2 * x, 10.0) - 2.0) < 10e-4
-@test norm(Calculus.finite_difference_hessian(x -> x^2, x -> 2 * x, 100.0) - 2.0) < 10e-4
+@testset "Second derivatives of f: R -> R" begin
+    @test norm(Calculus.finite_difference_hessian(x -> x^2, x -> 2 * x, 1.0) - 2.0) < 10e-4
+    @test norm(Calculus.finite_difference_hessian(x -> x^2, x -> 2 * x, 10.0) - 2.0) < 10e-4
+    @test norm(Calculus.finite_difference_hessian(x -> x^2, x -> 2 * x, 100.0) - 2.0) < 10e-4
 
-@test norm(Calculus.finite_difference_hessian(x -> x^2, 1.0) - 2.0) < 10e-4
-@test norm(Calculus.finite_difference_hessian(x -> x^2, 10.0) - 2.0) < 10e-4
-@test norm(Calculus.finite_difference_hessian(x -> x^2, 100.0) - 2.0) < 10e-4
+    @test norm(Calculus.finite_difference_hessian(x -> x^2, 1.0) - 2.0) < 10e-4
+    @test norm(Calculus.finite_difference_hessian(x -> x^2, 10.0) - 2.0) < 10e-4
+    @test norm(Calculus.finite_difference_hessian(x -> x^2, 100.0) - 2.0) < 10e-4
+end
 
 #
 # Hessians of f: R^n -> R
 #
 
-fx(x) = sin(x[1]) + cos(x[2])
-gx = Calculus.gradient(fx)
-@test norm(gx([0.0, 0.0]) - [cos(0.0), -sin(0.0)]) < 10e-4
-@test norm(Calculus.finite_difference_hessian(fx, gx, [0.0, 0.0], :central) - [-sin(0.0) 0.0; 0.0 -cos(0.0)]) < 10e-4
-@test norm(Calculus.finite_difference_hessian(fx, [0.0, 0.0]) - [-sin(0.0) 0.0; 0.0 -cos(0.0)]) < 10e-4
+@testset "Hessians of f: R^n -> R" begin
+    fx(x) = sin(x[1]) + cos(x[2])
+    gx = Calculus.gradient(fx)
+    x₁, x₂ = 1.0, 1.0
+    x = [x₁, x₂]
+    @test norm(gx(x) - [cos(x₁), -sin(x₂)]) < 10e-4
+    @test norm(Calculus.finite_difference_hessian(fx, gx, x, :central) - [-sin(x₁) 0.0; 0.0 -cos(x₂)]) < 10e-4
+    @test norm(Calculus.finite_difference_hessian(fx, x) - [-sin(x₁) 0.0; 0.0 -cos(x₂)]) < 10e-4
+end
 
 #
 # Taylor Series first derivatives
 #
 
-@test norm(Calculus.taylor_finite_difference(x -> x^2, 1.0, :forward) - 2.0) < 10e-4
-@test norm(Calculus.taylor_finite_difference(x -> x^2, 1.0, :central) - 2.0) < 10e-4
+@testset "Taylor Series first derivatives" begin
+    @test norm(Calculus.taylor_finite_difference(x -> x^2, 1.0, :forward) - 2.0) < 10e-4
+    @test norm(Calculus.taylor_finite_difference(x -> x^2, 1.0, :central) - 2.0) < 10e-4
+end
 
 #
 # Taylor Series second derivatives

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,8 @@ tests = ["finite_difference",
 
 println("Running tests:")
 
-for t in tests
-    println(" * $(t)")
-    include("$(t).jl")
+@testset "$t" for t in tests
+    include("$t.jl")
 end
+
+println("Tests finished.")


### PR DESCRIPTION
This PR basically removes the lower bound on the size of `epsilon`. It fixes the current problem for small `x` with some functions, like, e.g., `f(x) = log(x)`. MWE of the issue: 
```julia
julia> fun(x) = log(x)
fun (generic function with 1 method)

julia> x0 = 1e-50
1.0e-50

julia> Calculus.derivative(fun, x0, :central)
ERROR: DomainError with -6.0554544523933395e-6
```

It is not only a problem of throwing an error, it is also a problem for accuracy, as illustrated in @andreasnoack's slack example, reproduced here:
```julia
julia> [Calculus.derivative(log, x, :central)*x - 1 for x in [1e-2, 1e-3, 1e-4, 1e-5]] # gives a large relative error
4-element Array{Float64,1}:
 1.2222802592276594e-7
 1.2223111765852224e-5
 0.0012249805130359892
 0.1590499883576919

julia> function mycentraldiff(f, x) # no lower bound does not give such a large error
         ϵ = sqrt(eps(x))
         return (f(x + ϵ) - f(x - ϵ))/(2*ϵ)
       end
mycentraldiff (generic function with 1 method)

julia> [mycentraldiff(log, x)*x - 1 for x in [1e-2, 1e-3, 1e-4, 1e-5]]
4-element Array{Float64,1}:
 -2.5553159588298513e-10
  0.0
  0.0
 -3.9739767032642703e-11
```

Note this PR is not the ideal solution. In particular, the test for the gradient of `f(x) = sin(x[1]) + cos(x[2])` at `[0, 0]`, which currently passes thanks to the lower bound, does not pass with this PR. (I thus changed the test to be at `[1, 1]` rather than `[0, 0]`.)
My understanding is that even for simpler cases, e.g., for `f(x) = x + a`, where `a` is a "big", then `epsilon` must be big too in order to not be collapsed to `0` when added to `a`. (That means if `epsilon` just scales with `x`, the finite-difference will only work for `x` of a similar magnitude to `a`). 

However, this seems like a rarer and more pathological case than the `f(x) = log(x)` case to me. So my preference would go to removing the `max(1, abs(x))`, hence this PR.

As noted by Jeffrey Sarnoff, an ideal solution should implement some lower bound. Maybe one of you knows of a better way to implement said lower bound so that it is not a problem in the cases like `f(x) = log(x)`?

Another thing noted by @andreasnoack is that maybe `cbrt` is not ideal in `:central` difference and may be replaced by `sqrt` (as in the example above). I am not sure about that either, but I was told to explicitly raise the issue here as well 😃.

[Note on why I would like this to be solved:] I want to be able to use Julia's state-of-the-art numerical differentiation tools (AD, dual and hyperdual numbers, etc.) and would like to be able to quantify how these tools perform vs state-of-the-art finite differences in some specific scientific applications. But this `f(x) = log(x)` issue is preventing me from doing this...

Last note, I edited the tests quite a bit (apart from the `[0,0]`-to-`[1,1]` change), but it was mostly to enclose each group of tests in a `@testset` of its own for me to be able to find where the tests failed more easily.