### PR TITLE
Remove reference to prime notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,20 +90,6 @@ There are a few basic approaches to using the Calculus package:
 	h2([1.0, 1.0])
 	h2([pi, pi])
 
-## Prime Notation
-
-For scalar functions that map R to R, you can use the `'` operator to calculate
-derivatives as well. This operator can be used abritratily many times, but you
-should keep in mind that the approximation degrades with each approximate
-derivative you calculate:
-
-	using Calculus
-
-	f(x) = sin(x)
-	f'(1.0) - cos(1.0)
-	f''(1.0) - (-sin(1.0))
-	f'''(1.0) - (-cos(1.0))
-
 ## Symbolic Differentiation
 
 	using Calculus


### PR DESCRIPTION
It looks like #133 removed the overload that prime notation needed. In response, let's remove readme references to it.