### PR TITLE
Replaced eval with getfield in symbolic.jl

### DIFF
--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -93,7 +93,7 @@ function simplify(ex::Expr)
         return ex
     end
     if all(isnumber, ex.args[2:end]) && length(ex.args) > 1
-        return (@static (VERSION < v"0.7.0-DEV.5149") ? eval : Core.eval)(@__MODULE__, ex)
+        return getfield(Base,ex.args[1])(ex.args[2:end]...)
     end
     new_ex = simplify(SymbolParameter(ex.args[1]), ex.args[2:end])
     while !(isequal(new_ex, ex))


### PR DESCRIPTION
Replaced eval with getfield in symbolic.jl. The use of eval would break incremental parsing when used in another package.  Calculus package could not be used in other packages since julia 1.5.1 (?) where it would throw error instead of warnings due to the use of eval.
Example see [JuliaFEM](https://github.com/JuliaFEM/JuliaFEM.jl/issues/257)